### PR TITLE
Includes full list of available versions with GET /versions

### DIFF
--- a/cdn.js
+++ b/cdn.js
@@ -1,5 +1,5 @@
 /* DISCLAIMER
- * 
+ *
  * Parts of the code in this file dealing with version numbers
  * take the assumption that they're formatted as d.d.[d]d and
  * will NOT work if the major/medium has more than one digit.
@@ -44,18 +44,16 @@ var lowerCaseQuery = function (req, res, next) {
 /*
  * App environments configuration
  */
-app.configure(function() {
-	app.use(express.compress()); // gzip
-	app.use(allowCrossDomain);
-	app.use(lowerCaseQuery);
-	app.use('/aria', express.static(__dirname + '/aria', {maxAge: ONE_YEAR_MS}));
-	app.use('/dev', express.static(__dirname + '/dev', {maxAge: ONE_YEAR_MS}));
-	app.use('/css', express.static(__dirname + '/css', {maxAge: ONE_YEAR_MS}));
-	app.use(express.static(__dirname + '/static', {maxAge: ONE_YEAR_MS}));
-	app.use('/aria', express.directory(__dirname + '/aria', {icons:true}));
-	app.use('/dev', express.directory(__dirname + '/dev', {icons:true}));
-	app.use('/css', express.directory(__dirname + '/css', {icons:true}));
-});
+app.use(express.compress()); // gzip
+app.use(allowCrossDomain);
+app.use(lowerCaseQuery);
+app.use('/aria', express.static(__dirname + '/aria', {maxAge: ONE_YEAR_MS}));
+app.use('/dev', express.static(__dirname + '/dev', {maxAge: ONE_YEAR_MS}));
+app.use('/css', express.static(__dirname + '/css', {maxAge: ONE_YEAR_MS}));
+app.use(express.static(__dirname + '/static', {maxAge: ONE_YEAR_MS}));
+app.use('/aria', express.directory(__dirname + '/aria', {icons:true}));
+app.use('/dev', express.directory(__dirname + '/dev', {icons:true}));
+app.use('/css', express.directory(__dirname + '/css', {icons:true}));
 
 /*
  * Open-source build getter

--- a/cdn.js
+++ b/cdn.js
@@ -144,7 +144,8 @@ app.get('/updateconfig', function (req, res) {
 app.get('/versions', function (req, res) {
 	var versions = {
 		'min' : utils.config.OLDEST,
-		'max' : utils.config.LATEST
+		'max' : utils.config.LATEST,
+		'list' : utils.config.VERSIONS
 	};
 	res.type('application/json');
 	res.header('Cache-Control', 'public, max-age=' + ONE_YEAR);

--- a/cdnlib.js
+++ b/cdnlib.js
@@ -109,6 +109,10 @@ var sendFwk = function (req, res, content, version, dev, expire) {
 	res.send(r);
 }
 
+var formatVersion = function (version) {
+	return version.replace(/0(\d)$/, '$1');
+};
+
 /*
  * Reloads a configuration file into the configuration object, sets timestamp and determine OLDEST/LATEST versions
  */
@@ -126,14 +130,16 @@ var loadConfig = function(file, cb) {
 	config.LATEST_TS = (new Date()).toUTCString();
 	// listing files from the OS version to avoid patches
 	glob(__dirname + '/aria/ariatemplates\-*.js', null, function (er, files) {
-    var versions = [];
-    files.forEach(function(f){
+		var versions = [];
+		files.forEach(function(f){
  			var v = /\/ariatemplates-(\d)\.(\d)\.(\d{1,2})\.js$/.exec(f);
 			if (v) versions.push(v[1] + v[2] + (0 + v[3]).slice(-2)); // ariatemplates-a.b.c.js > ab[0]c
-    });
+		});
 		var sortedVersions = versions.sort(); // alphabetical sort will do fine
-		config.OLDEST = sortedVersions[0].replace(/0(\d)$/, '$1');
-		config.LATEST = sortedVersions[sortedVersions.length - 1].replace(/0(\d)$/, '$1');
+		config.VERSIONS = sortedVersions.map(formatVersion);
+		config.OLDEST = config.VERSIONS[0];
+		config.LATEST = config.VERSIONS[config.VERSIONS.length - 1];
+
 		cb.call(this);
 	})
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "git://github.com/ariatemplates/cdn.ariatemplates.com.git"
 	},
 	"dependencies" : {
-		"express" : ">=3.4.0",
+		"express" : "^3.4.0",
 		"glob" : ">=3.2.8"
 	},
 	"private" : true


### PR DESCRIPTION
This pull request makes the list of available versions available through the JSON REST API.

```
GET /versions
```

will now return something like:

``` json
{
  "min": "154",
  "max": "164",
  "list": [
    "154",
    "161",
    "162",
    "163",
    "164"
  ]
}
```
